### PR TITLE
Enhance star updater CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,15 @@ cd markdown-github-stars-updater
 2. Build and run the program:
 ```sh
 go build
-./markdown-github-stars-updater path/to/your/markdown/file.md
- ```
+./markdown-github-stars-updater [flags] path/to/your/markdown/file.md
+```
+Flags:
+```
+  -output string
+        output file path (defaults to input file)
+  -dry-run
+        print updated content instead of writing
+```
 Replace path/to/your/markdown/file.md with the path to your Markdown file.
 
 #### Download compiled
@@ -48,10 +55,12 @@ This program utilizes the GitHub API to fetch star counts for GitHub repositorie
 - If the star count is less than 1000, the exact star count is shown (e.g., "⭐35").
 - If the star count is between 1000 and 9999, it is displayed in the format "⭐1.1k" for 1100 stars.
 - If the star count is 10000 or more, it is displayed in the format "⭐10k" for 10000 stars.
+The tool processes one file at a time, so run it separately for each Markdown file you need to update. The link detection relies on a simple regular expression and may not cover every possible Markdown link variation.
 ## Requirements
 - Go programming language (https://golang.org/dl/)
 ## Configuration
-To use this program, you need to provide your GitHub access token for API requests. Set the GITHUB_TOKEN environment variable before running the program.
+To use this program, you need to provide your GitHub access token for API requests. Set the `GITHUB_TOKEN` environment variable before running the program.
+Using a token prevents hitting the very small unauthenticated rate limits of the GitHub API.
 
 ## License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for more information.

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -46,12 +47,42 @@ func TestRemoveStarsInfo(t *testing.T) {
 	}
 }
 
+func TestUpdateStarCounts(t *testing.T) {
+	original := `- [DapperDox](https://github.com/DapperDox/dapperdox)
+- [Explorer (⭐1k)](https://github.com/Rhosys/openapi-explorer)`
+
+	fetchStars = func(repoURL string) (int, error) {
+		switch repoURL {
+		case "https://github.com/DapperDox/dapperdox":
+			return 1500, nil
+		case "https://github.com/Rhosys/openapi-explorer":
+			return 250, nil
+		}
+		return 0, nil
+	}
+	defer func() { fetchStars = getStarsCount }()
+
+	updated, err := updateStarCounts(original)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `- [DapperDox (⭐1.5k)](https://github.com/DapperDox/dapperdox)
+- [Explorer (⭐250)](https://github.com/Rhosys/openapi-explorer)`
+	if strings.TrimSpace(updated) != strings.TrimSpace(expected) {
+		t.Errorf("unexpected update\nwant:\n%s\ngot:\n%s", expected, updated)
+	}
+}
+
 func TestGetAccessToken(t *testing.T) {
 	// Backup the existing environment variable and set a temporary one for the test
 	oldToken := os.Getenv("GITHUB_TOKEN")
 	os.Setenv("GITHUB_TOKEN", "test_token")
 
-	token := getAccessToken()
+	token, err := getAccessToken()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	if token != "test_token" {
 		t.Errorf("Expected 'test_token', got '%s'", token)
 	}
@@ -65,4 +96,16 @@ func TestParseRepoName(t *testing.T) {
 	if owner != "google" || repo != "go-github" {
 		t.Errorf("Expected google and go-github, got %s and %s", owner, repo)
 	}
+}
+
+func TestGetAccessTokenMissing(t *testing.T) {
+	oldToken := os.Getenv("GITHUB_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+
+	_, err := getAccessToken()
+	if err == nil {
+		t.Fatalf("Expected an error when token is missing")
+	}
+
+	os.Setenv("GITHUB_TOKEN", oldToken)
 }


### PR DESCRIPTION
## Summary
- add command flags for output and dry run
- provide error on missing `GITHUB_TOKEN` instead of exiting
- allow mocking GitHub API via `fetchStars` variable
- extend tests to cover token logic and updateStarCounts
- document new flags and token usage details

## Testing
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687bcfbb0bf0833288fbdbd3e769ec0f