### PR TITLE
Update CI, refactor link parsing & tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,21 +2,22 @@ name: Build & release
 
 on:
   push:
+    branches: [ main ]
     tags:
       - 'v*'
+  pull_request:
+    branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  build:
-    name: Build
+  lint-and-test:
+    name: Lint & Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Go environment
         uses: actions/setup-go@v5
@@ -27,9 +28,28 @@ jobs:
         run: |
           go tool golangci-lint run
           go tool govulncheck ./...
+          go tool nilaway ./...
 
       - name: Run tests
         run: go test -race -v ./...
+
+  release:
+    name: Build & Release
+    needs: lint-and-test
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
 
       - name: Build for Linux (AMD64)
         run: go build -v -o markdown-github-stars-updater-linux-amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Lint
         run: |
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Build for Linux (AMD64)
         run: go build -v -o markdown-github-stars-updater-linux-amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,32 +5,38 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go environment
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.24'
-        
       - name: Checkout code
-        uses: actions/checkout@v2
-        
-      - name: Get dependencies
-        run: go get -v -t -d ./...
-      
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Lint
+        run: |
+          go tool golangci-lint run
+          go tool govulncheck ./...
+
       - name: Run tests
-        run: go test -v ./...
-        
+        run: go test -race -v ./...
+
       - name: Build for Linux (AMD64)
         run: go build -v -o markdown-github-stars-updater-linux-amd64
         env:
           GOOS: linux
           GOARCH: amd64
           CGO_ENABLED: 0
-          GO111MODULE: on
 
       - name: Build for Linux (ARM64)
         run: go build -v -o markdown-github-stars-updater-linux-arm64
@@ -38,94 +44,35 @@ jobs:
           GOOS: linux
           GOARCH: arm64
           CGO_ENABLED: 0
-          GO111MODULE: on
-    
+
       - name: Build for Windows
         run: go build -v -o markdown-github-stars-updater-windows-amd64.exe
         env:
           GOOS: windows
           GOARCH: amd64
           CGO_ENABLED: 0
-          GO111MODULE: on
-            
+
       - name: Build for MacOS (AMD64)
         run: go build -v -o markdown-github-stars-updater-darwin-amd64
         env:
           GOOS: darwin
           GOARCH: amd64
           CGO_ENABLED: 0
-          GO111MODULE: on
-      
+
       - name: Build for MacOS (ARM64)
         run: go build -v -o markdown-github-stars-updater-darwin-arm64
         env:
           GOOS: darwin
           GOARCH: arm64
           CGO_ENABLED: 0
-          GO111MODULE: on
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release and upload assets
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Asset for Linux (AMD64)
-        id: upload-release-asset-linux-amd64
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./markdown-github-stars-updater-linux-amd64
-          asset_name: markdown-github-stars-updater-linux-amd64
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset for Linux (ARM64)
-        id: upload-release-asset-linux-arm64
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./markdown-github-stars-updater-linux-arm64
-          asset_name: markdown-github-stars-updater-linux-arm64
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset for Windows
-        id: upload-release-asset-windows
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./markdown-github-stars-updater-windows-amd64.exe
-          asset_name: markdown-github-stars-updater-windows-amd64.exe
-          asset_content_type: application/octet-stream
-      
-      - name: Upload Release Asset for MacOS (AMD64)
-        id: upload-release-asset-macos-amd64
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./markdown-github-stars-updater-darwin-amd64
-          asset_name: markdown-github-stars-updater-darwin-amd64
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset for MacOS (ARM64)
-        id: upload-release-asset-macos-arm64
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./markdown-github-stars-updater-darwin-arm64
-          asset_name: markdown-github-stars-updater-darwin-arm64
-          asset_content_type: application/octet-stream
+          generate_release_notes: true
+          files: |
+            markdown-github-stars-updater-linux-amd64
+            markdown-github-stars-updater-linux-arm64
+            markdown-github-stars-updater-windows-amd64.exe
+            markdown-github-stars-updater-darwin-amd64
+            markdown-github-stars-updater-darwin-arm64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+GEMINI.md

--- a/asciidoc.go
+++ b/asciidoc.go
@@ -7,16 +7,14 @@ import (
 	"strings"
 )
 
+var asciidocLinkRe = regexp.MustCompile(`(?:link:)?(https://github\.com/[^/\[]+/[^/\[]+)\[([^\]]*)\]`)
+
 // ASCIIDocUpdater implements LinkUpdater for AsciiDoc files.
 type ASCIIDocUpdater struct{}
 
 // FindRepos finds all GitHub repository links in the given content.
 func (a *ASCIIDocUpdater) FindRepos(content string) ([]string, error) {
-	// Pattern: (optional "link:") + (https://github.com/...) + [Text]
-	// Group 1: URL
-	// Group 2: Text (unused here but part of the structure)
-	re := regexp.MustCompile(`(?:link:)?(https://github\.com/[^\[]+)\[([^\]]*)\]`)
-	matches := re.FindAllStringSubmatch(content, -1)
+	matches := asciidocLinkRe.FindAllStringSubmatch(content, -1)
 
 	repos := make([]string, 0, len(matches))
 	for _, match := range matches {
@@ -27,8 +25,7 @@ func (a *ASCIIDocUpdater) FindRepos(content string) ([]string, error) {
 
 // UpdateContent updates the content by injecting star counts using the provided map.
 func (a *ASCIIDocUpdater) UpdateContent(content string, stars map[string]int) (string, error) {
-	re := regexp.MustCompile(`(?:link:)?(https://github\.com/[^\[]+)\[([^\]]*)\]`)
-	matches := re.FindAllStringSubmatch(content, -1)
+	matches := asciidocLinkRe.FindAllStringSubmatch(content, -1)
 
 	for _, match := range matches {
 		fullMatch := match[0]
@@ -40,8 +37,6 @@ func (a *ASCIIDocUpdater) UpdateContent(content string, stars map[string]int) (s
 			continue
 		}
 
-		// Reconstruct the link with updated stars
-		// We need to preserve the "link:" prefix if it was there
 		prefix := ""
 		if strings.HasPrefix(fullMatch, "link:") {
 			prefix = "link:"

--- a/asciidoc.go
+++ b/asciidoc.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-var asciidocLinkRe = regexp.MustCompile(`(?:link:)?(https://github\.com/[^/\[]+/[^/\[]+)\[([^\]]*)\]`)
+var asciidocLinkRe = regexp.MustCompile(`(?:link:)?(https://github\.com/[^/\[]+/[^\[]+)\[([^\]]*)\]`)
 
 // ASCIIDocUpdater implements LinkUpdater for AsciiDoc files.
 type ASCIIDocUpdater struct{}

--- a/asciidoc_test.go
+++ b/asciidoc_test.go
@@ -33,6 +33,16 @@ func TestAsciiDocFindRepos(t *testing.T) {
 			expected: []string{"https://github.com/owner/repo"},
 		},
 		{
+			name:     "Link with trailing path segments",
+			content:  "link:https://github.com/owner/repo/tree/main[Browse Source]",
+			expected: []string{"https://github.com/owner/repo/tree/main"},
+		},
+		{
+			name:     "Link to issues page",
+			content:  "https://github.com/owner/repo/issues[Issues]",
+			expected: []string{"https://github.com/owner/repo/issues"},
+		},
+		{
 			name:     "No links",
 			content:  "Just some text without links.",
 			expected: []string{},
@@ -83,6 +93,12 @@ func TestAsciiDocUpdateContent(t *testing.T) {
 			content:  "link:https://github.com/a/b[A] and https://github.com/c/d[B]",
 			stars:    map[string]int{"https://github.com/a/b": 10, "https://github.com/c/d": 20},
 			expected: "link:https://github.com/a/b[A (⭐10)] and https://github.com/c/d[B (⭐20)]",
+		},
+		{
+			name:     "Update link with trailing path",
+			content:  "link:https://github.com/owner/repo/tree/main[Source]",
+			stars:    map[string]int{"https://github.com/owner/repo/tree/main": 42},
+			expected: "link:https://github.com/owner/repo/tree/main[Source (⭐42)]",
 		},
 	}
 

--- a/asciidoc_test.go
+++ b/asciidoc_test.go
@@ -2,7 +2,7 @@
 package main
 
 import (
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -46,7 +46,7 @@ func TestAsciiDocFindRepos(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !reflect.DeepEqual(got, tt.expected) {
+			if !slices.Equal(got, tt.expected) {
 				t.Errorf("expected %v, got %v", tt.expected, got)
 			}
 		})

--- a/common.go
+++ b/common.go
@@ -16,12 +16,15 @@ type LinkUpdater interface {
 	UpdateContent(content string, stars map[string]int) (string, error)
 }
 
+var (
+	starsInfoRe  = regexp.MustCompile(`\s*\(⭐[^)]*\)`)
+	multiSpaceRe = regexp.MustCompile(`\s{2,}`)
+)
+
 // removeStarsInfo removes the existing star count information from the input string.
 func removeStarsInfo(input string) string {
-	// Create a regular expression to find the "(⭐...)" pattern
-	re := regexp.MustCompile(`\(⭐.*\)`)
-	// Replace the matched substrings with an empty string
-	result := re.ReplaceAllString(input, "")
+	result := starsInfoRe.ReplaceAllString(input, "")
+	result = multiSpaceRe.ReplaceAllString(result, " ")
 	return strings.TrimSpace(result)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stn1slv/github-markdown-stars-updater
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-github/v68 v68.0.0

--- a/main.go
+++ b/main.go
@@ -142,8 +142,13 @@ func getStarsCount(ctx context.Context, client *github.Client, repoURL string) (
 	return repository.GetStargazersCount(), nil
 }
 
-// parseRepoName takes a path like "owner/repo" (possibly with trailing segments) and returns the owner and repo parts.
+// parseRepoName takes a path like "owner/repo" (possibly with trailing segments, query strings, or fragments)
+// and returns the owner and repo parts.
 func parseRepoName(repoPath string) (string, string, error) {
+	// Strip query string (?...) and fragment (#...) before splitting
+	if idx := strings.IndexAny(repoPath, "?#"); idx != -1 {
+		repoPath = repoPath[:idx]
+	}
 	parts := strings.SplitN(repoPath, "/", 3) //nolint:mnd
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid repository path: %q", repoPath)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,13 +146,17 @@ func getStarsCount(ctx context.Context, client *github.Client, repoURL string) (
 // parseRepoName takes a path like "owner/repo" (possibly with trailing segments, query strings, or fragments)
 // and returns the owner and repo parts.
 func parseRepoName(repoPath string) (string, string, error) {
-	// Strip query string (?...) and fragment (#...) before splitting
-	if idx := strings.IndexAny(repoPath, "?#"); idx != -1 {
-		repoPath = repoPath[:idx]
+	// Use net/url to correctly parse query parameters and fragments
+	u, err := url.Parse(repoPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse repository path: %w", err)
 	}
-	parts := strings.SplitN(repoPath, "/", 3) //nolint:mnd
+
+	// We only care about the path part of the URL
+	path := strings.TrimPrefix(u.Path, "/")
+	parts := strings.SplitN(path, "/", 3) //nolint:mnd
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("invalid repository path: %q", repoPath)
+		return "", "", fmt.Errorf("invalid repository path: %q", path)
 	}
 	return parts[0], parts[1], nil
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const githubURLPrefix = "https://github.com/"
+
 var version = "dev"
 
 func main() {
@@ -28,24 +30,24 @@ func main() {
 	}
 
 	if flag.NArg() < 1 {
-		fmt.Println("Usage: markdown-github-stars-updater [flags] <path_to_file>")
+		fmt.Fprintln(os.Stderr, "Usage: markdown-github-stars-updater [flags] <path_to_file>")
 		flag.PrintDefaults()
-		return
+		os.Exit(1)
 	}
 
 	filePath := flag.Arg(0)
 
 	contentBytes, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
-		fmt.Println("Error reading the file:", err)
-		return
+		fmt.Fprintln(os.Stderr, "Error reading the file:", err)
+		os.Exit(1)
 	}
 	content := string(contentBytes)
 
 	token, err := getAccessToken()
 	if err != nil {
-		fmt.Println("Error:", err)
-		return
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
 	}
 
 	client := newGitHubClient(token)
@@ -67,15 +69,15 @@ func main() {
 		// but explicit support for asciidoc is added.
 		// Let's print a warning and default to markdown for now, or just fail.
 		// Failing is safer to avoid corrupting other files.
-		fmt.Printf("Unsupported file extension: %s. Supported: .md, .markdown, .adoc, .asciidoc\n", ext)
-		return
+		fmt.Fprintf(os.Stderr, "Unsupported file extension: %s. Supported: .md, .markdown, .adoc, .asciidoc\n", ext)
+		os.Exit(1)
 	}
 
 	// 1. Find Repos
 	repos, err := updater.FindRepos(content)
 	if err != nil {
-		fmt.Println("Error finding repositories:", err)
-		return
+		fmt.Fprintln(os.Stderr, "Error finding repositories:", err)
+		os.Exit(1)
 	}
 
 	// 2. Fetch Stars
@@ -85,9 +87,9 @@ func main() {
 		if _, exists := stars[repoURL]; exists {
 			continue
 		}
-		count, err := getStarsCount(ctx, client, repoURL)
-		if err != nil {
-			fmt.Printf("Warning: Could not fetch stars for %s: %v\n", repoURL, err)
+		count, fetchErr := getStarsCount(ctx, client, repoURL)
+		if fetchErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Could not fetch stars for %s: %v\n", repoURL, fetchErr)
 			continue
 		}
 		stars[repoURL] = count
@@ -96,8 +98,8 @@ func main() {
 	// 3. Update Content
 	updatedContent, err := updater.UpdateContent(content, stars)
 	if err != nil {
-		fmt.Println("Error updating content:", err)
-		return
+		fmt.Fprintln(os.Stderr, "Error updating content:", err)
+		os.Exit(1)
 	}
 
 	if *dryRun {
@@ -114,16 +116,24 @@ func main() {
 	// We use 0644 because this is a documentation tool and the files are usually public/shared.
 	err = os.WriteFile(output, []byte(updatedContent), 0o644) //nolint:gosec
 	if err != nil {
-		fmt.Println("Error writing updated file:", err)
-		return
+		fmt.Fprintln(os.Stderr, "Error writing updated file:", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("File updated successfully.")
 }
 
-// getStarsCount takes a GitHub repository URL and returns the current number of stars
+// getStarsCount takes a GitHub repository URL and returns the current number of stars.
 func getStarsCount(ctx context.Context, client *github.Client, repoURL string) (int, error) {
-	owner, repo := parseRepoName(repoURL[len("https://github.com/"):])
+	if !strings.HasPrefix(repoURL, githubURLPrefix) {
+		return 0, fmt.Errorf("invalid GitHub URL: %s", repoURL)
+	}
+
+	owner, repo, err := parseRepoName(repoURL[len(githubURLPrefix):])
+	if err != nil {
+		return 0, err
+	}
+
 	repository, _, err := client.Repositories.Get(ctx, owner, repo)
 	if err != nil {
 		return 0, err
@@ -132,13 +142,13 @@ func getStarsCount(ctx context.Context, client *github.Client, repoURL string) (
 	return repository.GetStargazersCount(), nil
 }
 
-// parseRepoName takes a GitHub repository name (formatted as "owner/repo") and returns the owner and repo parts.
-func parseRepoName(repoName string) (string, string) {
-	parts := strings.Split(repoName, "/")
-	if len(parts) != 2 {
-		panic("Invalid repository name format")
+// parseRepoName takes a path like "owner/repo" (possibly with trailing segments) and returns the owner and repo parts.
+func parseRepoName(repoPath string) (string, string, error) {
+	parts := strings.SplitN(repoPath, "/", 3) //nolint:mnd
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid repository path: %q", repoPath)
 	}
-	return parts[0], parts[1]
+	return parts[0], parts[1], nil
 }
 
 // getAccessToken retrieves the GitHub access token from the environment variable

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/google/go-github/v68/github"
@@ -44,6 +43,7 @@ func TestRemoveStarsInfo(t *testing.T) {
 		{"Project1 (⭐1k)", "Project1"},
 		{"Project2 (⭐1.5k)", "Project2"},
 		{"Project3", "Project3"},
+		{"Project4 (⭐1k) (extra notes)", "Project4 (extra notes)"},
 	}
 
 	for _, test := range tests {
@@ -55,8 +55,7 @@ func TestRemoveStarsInfo(t *testing.T) {
 }
 
 func TestGetAccessToken(t *testing.T) {
-	oldToken := os.Getenv("GITHUB_TOKEN")
-	_ = os.Setenv("GITHUB_TOKEN", "test_token")
+	t.Setenv("GITHUB_TOKEN", "test_token")
 
 	token, err := getAccessToken()
 	if err != nil {
@@ -65,31 +64,134 @@ func TestGetAccessToken(t *testing.T) {
 	if token != "test_token" {
 		t.Errorf("Expected 'test_token', got '%s'", token)
 	}
-
-	_ = os.Setenv("GITHUB_TOKEN", oldToken)
 }
 
 func TestGetAccessTokenMissing(t *testing.T) {
-	oldToken := os.Getenv("GITHUB_TOKEN")
-	_ = os.Unsetenv("GITHUB_TOKEN")
+	t.Setenv("GITHUB_TOKEN", "")
 
 	_, err := getAccessToken()
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-
-	_ = os.Setenv("GITHUB_TOKEN", oldToken)
 }
 
 func TestParseRepoName(t *testing.T) {
-	owner, repo := parseRepoName("google/go-github")
-	if owner != "google" || repo != "go-github" {
-		t.Errorf("Expected google and go-github, got %s and %s", owner, repo)
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{
+			name:      "Simple owner/repo",
+			input:     "google/go-github",
+			wantOwner: "google",
+			wantRepo:  "go-github",
+		},
+		{
+			name:      "With trailing path segments",
+			input:     "owner/repo/tree/main",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			name:    "Single segment",
+			input:   "owner",
+			wantErr: true,
+		},
+		{
+			name:    "Empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "Missing repo",
+			input:   "owner/",
+			wantErr: true,
+		},
+		{
+			name:    "Missing owner",
+			input:   "/repo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, err := parseRepoName(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("expected (%s, %s), got (%s, %s)", tt.wantOwner, tt.wantRepo, owner, repo)
+			}
+		})
 	}
 }
 
-// Helper to simulate the update flow for tests
+func TestMarkdownFindRepos(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "Single link",
+			content:  "- [Project](https://github.com/owner/repo)",
+			expected: []string{"https://github.com/owner/repo"},
+		},
+		{
+			name:     "Multiple links",
+			content:  "[A](https://github.com/a/b) and [B](https://github.com/c/d)",
+			expected: []string{"https://github.com/a/b", "https://github.com/c/d"},
+		},
+		{
+			name:     "Link with existing stars",
+			content:  "[Repo (⭐100)](https://github.com/owner/repo)",
+			expected: []string{"https://github.com/owner/repo"},
+		},
+		{
+			name:     "Non-GitHub link ignored",
+			content:  "[Docs](https://docs.example.com/guide)",
+			expected: []string{},
+		},
+		{
+			name:     "No links",
+			content:  "Just some text without links.",
+			expected: []string{},
+		},
+	}
+
+	updater := &MarkdownUpdater{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := updater.FindRepos(tt.content)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("index %d: expected %q, got %q", i, tt.expected[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+// Helper to simulate the update flow for tests.
 func runUpdateFlow(t *testing.T, content string, client *github.Client, updater LinkUpdater) string {
+	t.Helper()
+
 	repos, err := updater.FindRepos(content)
 	if err != nil {
 		t.Fatalf("FindRepos failed: %v", err)
@@ -98,9 +200,9 @@ func runUpdateFlow(t *testing.T, content string, client *github.Client, updater 
 	stars := make(map[string]int)
 	ctx := context.Background()
 	for _, repoURL := range repos {
-		count, err := getStarsCount(ctx, client, repoURL)
-		if err != nil {
-			t.Fatalf("getStarsCount failed for %s: %v", repoURL, err)
+		count, fetchErr := getStarsCount(ctx, client, repoURL)
+		if fetchErr != nil {
+			t.Fatalf("getStarsCount failed for %s: %v", repoURL, fetchErr)
 		}
 		stars[repoURL] = count
 	}
@@ -114,7 +216,7 @@ func runUpdateFlow(t *testing.T, content string, client *github.Client, updater 
 
 func TestUpdateStarCounts(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/testowner/testrepo", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/testowner/testrepo", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"stargazers_count": 42}`)
 	})
@@ -136,11 +238,11 @@ func TestUpdateStarCounts(t *testing.T) {
 
 func TestUpdateStarCountsMultiple(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/owner/repo1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/owner/repo1", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"stargazers_count": 1}`)
 	})
-	mux.HandleFunc("/repos/owner/repo2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/owner/repo2", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"stargazers_count": 2}`)
 	})
@@ -162,7 +264,7 @@ func TestUpdateStarCountsMultiple(t *testing.T) {
 
 func TestUpdateStarCountsExistingStars(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/owner/repo", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/owner/repo", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"stargazers_count": 10}`)
 	})
@@ -184,7 +286,7 @@ func TestUpdateStarCountsExistingStars(t *testing.T) {
 
 func TestUpdateStarCountsAsciiDoc(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/testowner/adoc-repo", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/testowner/adoc-repo", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"stargazers_count": 99}`)
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -115,6 +115,24 @@ func TestParseRepoName(t *testing.T) {
 			input:   "/repo",
 			wantErr: true,
 		},
+		{
+			name:      "With query string",
+			input:     "owner/repo?tab=readme",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "With fragment",
+			input:     "owner/repo#installation",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "With trailing path and query",
+			input:     "owner/repo/tree/main?file=README.md",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
 	}
 
 	for _, tt := range tests {

--- a/markdown.go
+++ b/markdown.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 )
 
+var markdownLinkRe = regexp.MustCompile(`\[([^\]]+)\]\((https://github\.com/[^/)]+/[^/)]+)\)`)
+
 // MarkdownUpdater implements LinkUpdater for Markdown files.
 type MarkdownUpdater struct{}
 
 // FindRepos finds all GitHub repository links in the given content.
 func (m *MarkdownUpdater) FindRepos(content string) ([]string, error) {
-	re := regexp.MustCompile(`\[([^\]]+)\]\((https:\/\/github\.com\/[^\/)]+\/[^\/)]+)\)`)
-	matches := re.FindAllStringSubmatch(content, -1)
+	matches := markdownLinkRe.FindAllStringSubmatch(content, -1)
 	repos := make([]string, 0, len(matches))
 	for _, match := range matches {
 		repos = append(repos, match[2])
@@ -23,16 +24,7 @@ func (m *MarkdownUpdater) FindRepos(content string) ([]string, error) {
 
 // UpdateContent updates the content by injecting star counts using the provided map.
 func (m *MarkdownUpdater) UpdateContent(content string, stars map[string]int) (string, error) {
-	re := regexp.MustCompile(`\[([^\]]+)\]\((https:\/\/github\.com\/[^\/)]+\/[^\/)]+)\)`)
-	matches := re.FindAllStringSubmatch(content, -1)
-
-	// We replace one by one. To avoid issues with multiple same links, we should be careful.
-	// The original code did `strings.Replace(..., match[0], ..., 1)` which iterates linearly.
-	// This is safe if we iterate the same way.
-
-	// However, modifying the string while iterating matches can be tricky if offsets change.
-	// But `strings.Replace` searches for the substring.
-	// Let's stick to the original logic for now which seemed to work for simple cases.
+	matches := markdownLinkRe.FindAllStringSubmatch(content, -1)
 
 	for _, match := range matches {
 		fullMatch := match[0]
@@ -41,8 +33,6 @@ func (m *MarkdownUpdater) UpdateContent(content string, stars map[string]int) (s
 
 		starCount, ok := stars[repoURL]
 		if !ok {
-			// If we didn't fetch stars for this repo (e.g. error or skipped), keep original?
-			// Or maybe we process all we found.
 			continue
 		}
 


### PR DESCRIPTION
Revamp GitHub Actions workflow (checkout@v4, setup-go@v5, Go 1.25), add permissions, linting (golangci-lint + govulncheck), race-enabled tests, and simplify release/upload via softprops/action-gh-release. Introduce/standardize regex variables for Markdown and AsciiDoc link matching, consolidate star-info removal logic, and improve whitespace handling. Harden main logic and error handling: validate GitHub URL prefix, return errors from parseRepoName, print errors to stderr and use os.Exit on failure. Update and expand tests (use slices, t.Setenv, additional parse and markdown/asciidoc cases) and minor test handler cleanups. Add CLAUDE.md symlink to GEMINI.md.